### PR TITLE
`enable` key might not exist

### DIFF
--- a/src/Items/Collector.php
+++ b/src/Items/Collector.php
@@ -239,7 +239,7 @@ class Collector
                 continue;
             }
             $item = $data[$index];
-            if (! $item['enabled']) {
+            if (! Arr::has($item, 'enabled')) {
                 continue;
             }
             $set = $value->fieldtype()->augment([$item])[0];


### PR DESCRIPTION
For some reason there's some content w/o the `enable` key, let's just ignore it