### PR TITLE
Handle strings in Bard field

### DIFF
--- a/src/Distill.php
+++ b/src/Distill.php
@@ -104,7 +104,7 @@ class Distill
             ->map(fn ($value) => match ($value->fieldtype()->handle()) {
                 'text' => $value->value(),
                 'textarea' => $value->value(),
-                'bard' => Statamic::modify($value)->bardText()->fetch(),
+                'bard' => is_string($value->raw()) ? $value->raw() : Statamic::modify($value)->bardText()->fetch(),
                 'markdown' => Statamic::modify($value)->stripTags()->fetch(),
                 default => null,
             })

--- a/src/Distill.php
+++ b/src/Distill.php
@@ -104,7 +104,7 @@ class Distill
             ->map(fn ($value) => match ($value->fieldtype()->handle()) {
                 'text' => $value->value(),
                 'textarea' => $value->value(),
-                'bard' => is_string($value->raw()) ? $value->raw() : Statamic::modify($value)->bardText()->fetch(),
+                'bard' => Statamic::modify($value)->bardText()->fetch(),
                 'markdown' => Statamic::modify($value)->stripTags()->fetch(),
                 default => null,
             })

--- a/src/Items/Collector.php
+++ b/src/Items/Collector.php
@@ -258,7 +258,8 @@ class Collector
 
     protected function collectBard(Value $value, $path)
     {
-        if (is_string($raw = $value->raw())) {
+        $raw = $value->raw();
+        if (is_string($raw)) {
             return true;
         }
 

--- a/src/Items/Collector.php
+++ b/src/Items/Collector.php
@@ -258,7 +258,11 @@ class Collector
 
     protected function collectBard(Value $value, $path)
     {
-        return $this->collectBardNodes($value->raw() ?? [], $path, $value->fieldtype());
+        if (is_string($raw = $value->raw())) {
+            return true;
+        }
+
+        return $this->collectBardNodes($raw ?? [], $path, $value->fieldtype());
     }
 
     protected function collectBardNodes($nodes, $path, Bard $fieldtype)


### PR DESCRIPTION
Very legacy content might be saved as HTML (and therefore a string) and never resaved. When Distill tries to extract the text it's expecting prose mirror data, not a string.