### PR TITLE
Ignore unsupported objects

### DIFF
--- a/src/Items/Collector.php
+++ b/src/Items/Collector.php
@@ -94,7 +94,7 @@ class Collector
                 ])) {
                     throw new Exception('Unsupported raw type: '.$raw);
                 } elseif ($type === Distill::TYPE_RAW_OBJECT && ! $value instanceof stdClass) {
-                    throw new Exception('Unsupported object type: '.get_class($value));
+                    return true;
                 }
             }
         }

--- a/src/Items/Collector.php
+++ b/src/Items/Collector.php
@@ -2,7 +2,6 @@
 
 namespace JackSleight\StatamicDistill\Items;
 
-use Exception;
 use Illuminate\Support\Collection;
 use JackSleight\StatamicDistill\Distill;
 use Statamic\Contracts\Assets\Asset;
@@ -92,8 +91,9 @@ class Collector
                     Distill::TYPE_RAW_OBJECT,
                     Distill::TYPE_RAW_STRING,
                 ])) {
-                    throw new Exception('Unsupported raw type: '.$raw);
-                } elseif ($type === Distill::TYPE_RAW_OBJECT && ! $value instanceof stdClass) {
+                    return true;
+                }
+                if ($type === Distill::TYPE_RAW_OBJECT && ! $value instanceof stdClass) {
                     return true;
                 }
             }


### PR DESCRIPTION
I ended up with a situation where a field is a Carbon object (this was a hidden computed field). This caused Distill to throw an error and prevented my client from saving.

Instead of throwing an error, I think ignoring is a better solution so that everything continues to work.