### PR TITLE
Support any class and other unknown values

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The `{{ distill:* }}` tag accepts the following parameters:
   * `term:[taxonomy]` - A term
   * `asset:[container]` - An asset
   * `user` - A user
-  * `raw:[php-type]` - A raw value
+  * `raw:[php-type]` - A raw value (inc. stdClass)
+  * `class:[php-class]` - Any other object (exc. stdClass)
 * **path (string|array)**  
   The path to match, asterisks can be used as a wildcard and multiple paths can be pipe delimited, paths themselves are dot delimited.
 * **depth (integer)**  

--- a/src/Distill.php
+++ b/src/Distill.php
@@ -18,6 +18,8 @@ class Distill
 
     const TYPE_RAW = 'raw';
 
+    const TYPE_CLASS = 'class';
+
     const TYPE_RAW_ARRAY = 'raw:array';
 
     const TYPE_RAW_BOOLEAN = 'raw:boolean';
@@ -31,6 +33,8 @@ class Distill
     const TYPE_RAW_OBJECT = 'raw:object';
 
     const TYPE_RAW_STRING = 'raw:string';
+
+    const TYPE_RAW_UNKNOWN = 'raw:unknown';
 
     const TYPE_ROW = 'row';
 
@@ -55,6 +59,8 @@ class Distill
     const TYPE_VALUE_TERMS = 'value:terms';
 
     const TYPE_VALUE_USERS = 'value:users';
+
+    const TYPE_VALUE_UNKNOWN = 'value:unknown';
 
     const SET_TYPE_BARD = 'bard';
 


### PR DESCRIPTION
This PR adds support for objects of any class and other unknown value types. Previously these types would throw exceptions.

Any non `stdClass` object will now have a type like `class:Carbon\Carbon`.